### PR TITLE
Fixes #2967

### DIFF
--- a/atomics/T1486/T1486.yaml
+++ b/atomics/T1486/T1486.yaml
@@ -333,7 +333,7 @@ atomic_tests:
       echo "If you' re indeed interested in our assistance and the services we provide you can reach out to us following simple instructions:" >> $env:Userprofile\Desktop\akira_readme.txt
       echo "" >> $env:Userprofile\Desktop\akira_readme.txt
       echo "1. Install TOR Browser to get access to our chat room - https://www.torproject.org/download/." >> $env:Userprofile\Desktop\akira_readme.txt
-      echo "2. Paste this link — https://akira.onion" >> $env:Userprofile\Desktop\akira_readme.txt
+      echo "2. Paste this link - https://akira.onion" >> $env:Userprofile\Desktop\akira_readme.txt
       echo "3. Use this code - - to log into our chat." >> $env:Userprofile\Desktop\akira_readme.txt
       echo "" >> $env:Userprofile\Desktop\akira_readme.txt
       echo "Keep in mind that the faster you will get in touch, the less damage we cause" >> $env:Userprofile\Desktop\akira_readme.txt


### PR DESCRIPTION
This fixes issue #2967 . The line contains an "em-dash" character (—) , which apparently break a powershell string when executed as a script. Strangely enough, running this line manually from a command line session works without complaints.

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->